### PR TITLE
Add build docs and compile tweaks

### DIFF
--- a/obsidian-continue/README.md
+++ b/obsidian-continue/README.md
@@ -1,0 +1,7 @@
+# Obsidian Continue Plugin
+
+This plugin adds an AI-powered command that can continue selected text inside Obsidian. It uses OpenAI's completion API. Configure your API key in the plugin settings, select some text, and run the command **Continue Selection with AI** to generate the continuation.
+
+## Build
+
+Run `npm install` to install development dependencies and then `npm run build` to compile the plugin. The compiled file will be generated in `dist/main.js`.

--- a/obsidian-continue/manifest.json
+++ b/obsidian-continue/manifest.json
@@ -1,0 +1,10 @@
+{
+ "id": "obsidian-continue",
+ "name": "Obsidian Continue",
+ "version": "0.1.0",
+ "minAppVersion": "0.15.0",
+ "description": "AI-assisted text continuation inspired by the Continue VS Code extension",
+ "author": "Example",
+ "authorUrl": "https://example.com",
+ "isDesktopOnly": false
+}

--- a/obsidian-continue/obsidian.d.ts
+++ b/obsidian-continue/obsidian.d.ts
@@ -1,0 +1,29 @@
+declare module 'obsidian' {
+  export class App {}
+  export class Plugin {
+    app: App;
+    addCommand(options: any): void;
+    addSettingTab(tab: any): void;
+    loadData?(): Promise<any>;
+    saveData?(data: any): Promise<void>;
+  }
+  export class PluginSettingTab {
+    plugin: Plugin;
+    containerEl: HTMLElement;
+    constructor(app: App, plugin: Plugin);
+    display(): void;
+  }
+  export class Setting {
+    constructor(containerEl: HTMLElement);
+    setName(name: string): this;
+    setDesc(desc: string): this;
+    addText(cb: (el: any) => any): this;
+  }
+  export class MarkdownView {}
+  export class Modal {}
+}
+
+interface HTMLElement {
+  empty(): void;
+  createEl(tag: string, options?: any): HTMLElement;
+}

--- a/obsidian-continue/package.json
+++ b/obsidian-continue/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "obsidian-continue",
+  "version": "0.1.0",
+  "description": "AI-assisted text continuation plugin for Obsidian",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p ."
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0"
+  }
+}

--- a/obsidian-continue/src/main.ts
+++ b/obsidian-continue/src/main.ts
@@ -1,0 +1,88 @@
+import { App, MarkdownView, Modal, Plugin, PluginSettingTab, Setting } from 'obsidian';
+
+export interface ContinuePluginSettings {
+    openAIApiKey: string;
+}
+
+const DEFAULT_SETTINGS: ContinuePluginSettings = {
+    openAIApiKey: ''
+};
+
+export default class ContinuePlugin extends Plugin {
+    settings: ContinuePluginSettings;
+
+    async onload() {
+        await this.loadSettings();
+
+        this.addCommand({
+            id: 'continue-selection',
+            name: 'Continue Selection with AI',
+            editorCallback: (editor) => this.continueSelection(editor.getSelection()).then(result => {
+                if (result) {
+                    const cursor = editor.getCursor();
+                    editor.replaceRange(result, cursor);
+                }
+            })
+        });
+
+        this.addSettingTab(new ContinueSettingTab(this.app, this));
+    }
+
+    onunload() {}
+
+    async continueSelection(text: string): Promise<string | null> {
+        if (!this.settings.openAIApiKey || !text) return null;
+
+        const response = await fetch('https://api.openai.com/v1/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${this.settings.openAIApiKey}`
+            },
+            body: JSON.stringify({
+                model: 'text-davinci-003',
+                prompt: text,
+                max_tokens: 100
+            })
+        });
+
+        if (!response.ok) return null;
+        const json = await response.json();
+        return json.choices?.[0]?.text?.trim() ?? null;
+    }
+
+    async loadSettings() {
+        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    }
+
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
+}
+
+class ContinueSettingTab extends PluginSettingTab {
+    plugin: ContinuePlugin;
+
+    constructor(app: App, plugin: ContinuePlugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
+
+    display(): void {
+        const { containerEl } = this;
+
+        containerEl.empty();
+        containerEl.createEl('h2', { text: 'Continue Plugin Settings' });
+
+        new Setting(containerEl)
+            .setName('OpenAI API Key')
+            .setDesc('API key used for generating continuations')
+            .addText(text => text
+                .setPlaceholder('sk-...')
+                .setValue(this.plugin.settings.openAIApiKey)
+                .onChange(async (value) => {
+                    this.plugin.settings.openAIApiKey = value.trim();
+                    await this.plugin.saveSettings();
+                }));
+    }
+}

--- a/obsidian-continue/tsconfig.json
+++ b/obsidian-continue/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "allowJs": false,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*",
+    "obsidian.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- configure output directory for plugin
- add stub obsidian typings
- document build steps

## Testing
- `npx tsc -p obsidian-continue`

------
https://chatgpt.com/codex/tasks/task_e_68407ad0f3988324a7eb70f1cfce73d0